### PR TITLE
Use grpc version 4 instead of 3.

### DIFF
--- a/complete/books/books.pb.go
+++ b/complete/books/books.pb.go
@@ -104,7 +104,7 @@ var _ grpc.ClientConn
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion3
+const _ = grpc.SupportPackageIsVersion4
 
 // Client API for BookService service
 

--- a/start/books/books.pb.go
+++ b/start/books/books.pb.go
@@ -104,7 +104,7 @@ var _ grpc.ClientConn
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion3
+const _ = grpc.SupportPackageIsVersion4
 
 // Client API for BookService service
 


### PR DESCRIPTION
This fixes the "undefined: grpc.SupportPackageIsVersion3" error in the
codelab.

Fix for issue #5 .